### PR TITLE
Fix breaking api change

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 import { moduleNameMapper } from './path.factory';
 
-export const bootstrap = (path?: string) => moduleNameMapper(path);
+const bootstrap = (path?: string) => moduleNameMapper(path);
+
+export default bootstrap;


### PR DESCRIPTION
 Because of the change made in this commit (https://github.com/sebastianmusial/jest-module-name-mapper/commit/54b9df7da0406af1cfde2d8693ae243230f63e8b#diff-f41e9d04a45c83f3b6f6e630f10117fe) going from an anonymous export to a named export, the library does not work as described in the README.

This PR aims to restore the default behaviour.

Current behaviour of the published package: 
```
const jestModuleNameMapper = require('jest-module-name-mapper').bootstrap();
```

Expected behaviour in this PR: 
```
const jestModuleNameMapper = require('jest-module-name-mapper')();
```